### PR TITLE
Added notification on print failure

### DIFF
--- a/octoprint_octobullet/templates/octobullet_settings.jinja2
+++ b/octoprint_octobullet/templates/octobullet_settings.jinja2
@@ -63,6 +63,33 @@
     </fieldset>
 
     <fieldset>
+        <legend>{{ _('Messages on print failure') }}</legend>
+
+        <div class="control-group">
+            <label class="control-label">{{ _('Message title') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.settings.plugins.octobullet.printFailed.title">
+            </div>
+        </div>
+
+        <div class="control-group">
+            <label class="control-label">{{ _('Message body') }}</label>
+            <div class="controls">
+                <textarea rows="4" class="block" data-bind="value: settings.settings.plugins.octobullet.printFailed.body"></textarea>
+            </div>
+        </div>
+
+        <div class="control-group">
+            <div class="controls">
+                <span class="help-block">{% trans %}
+                    Available placeholders: <code>{file}</code> - Failed file, <code>{elapsed_time}</code> - duration of the print
+                {% endtrans %}</span>
+            </div>
+        </div>
+
+    </fieldset>
+	
+    <fieldset>
         <legend>{{ _('Messages on print progress') }}</legend>
 
         <div class="control-group">


### PR DESCRIPTION
Added a notification on printFailed event because I wanted it and it was part of issue #11. I have tested and it works fine when I unplug the USB after starting a print which was the best test I can think of.