### PR TITLE
Fix rotate/flip snapshot handling before sending

### DIFF
--- a/octoprint_octobullet/__init__.py
+++ b/octoprint_octobullet/__init__.py
@@ -362,7 +362,7 @@ class PushbulletPlugin(octoprint.plugin.EventHandlerPlugin,
 				tempFile.name += ".jpg"
 
 				# flip or rotate as needed
-				self._process_snapshot(tempFile)
+				self._process_snapshot(tempFile.name)
 
 				if self._send_file(sender, tempFile.name, filename, title + " " + body):
 					return True


### PR DESCRIPTION
Previous commit 314985bd61720a0a6b53ca034713a20c64c81b32 introduced tempFile
object in place of snapshot_path string, hence _process_snapshot() should
get the filename instead of the whole object to work.

https://github.com/OctoPrint/OctoPrint-Pushbullet/commit/314985bd61720a0a6b53ca034713a20c64c81b32

Closes #34 

Signed-off-by: Denys Dmytriyenko <denis@denix.org>